### PR TITLE
fix(parser): validate text component hex color values

### DIFF
--- a/src/parser/JSONToHTML.ts
+++ b/src/parser/JSONToHTML.ts
@@ -61,9 +61,17 @@ export default function parseJSONToHTML(
         } else if (Object.hasOwn(colorCodeToHex, colorKey)) {
           colorHex = colorCodeToHex[colorKey];
           // custom color
-        } else if (colorKey.match(/^#?[0-9A-Fa-f]{6}$/)) {
-          // custom hex color code mode. Prepend a # if not present
-          colorHex = colorKey.replace(/^([^#])/, "#$1");
+        } else {
+          let customHexColorMatches = colorKey.match(
+            /^#([-+]?0+|\+?0*[1-9A-Fa-f][0-9A-Fa-f]{0,5})$/,
+          );
+
+          if (customHexColorMatches !== null) {
+            // custom hex color code mode
+            colorHex =
+              "#" +
+              customHexColorMatches[1].replace(/^[-+]?0*/, "").padStart(6, "0");
+          }
         }
       }
 

--- a/src/parser/JSONToHTML.ts
+++ b/src/parser/JSONToHTML.ts
@@ -61,9 +61,9 @@ export default function parseJSONToHTML(
         } else if (Object.hasOwn(colorCodeToHex, colorKey)) {
           colorHex = colorCodeToHex[colorKey];
           // custom color
-        } else {
-          // custom hex color code mode
-          colorHex = colorKey;
+        } else if (colorKey.match(/^#?[0-9A-Fa-f]{6}$/)) {
+          // custom hex color code mode. Prepend a # if not present
+          colorHex = colorKey.replace(/^([^#])/, "#$1");
         }
       }
 


### PR DESCRIPTION
This makes naive concatenation of these values to form CSS color rules work more predictably, with no exposure to CSS and/or HTML injection attacks.

While at it, I've also improved the resiliency of the parser for values that may lack a leading `#`.